### PR TITLE
Catch verify options error(s)

### DIFF
--- a/lib/ssllabs.js
+++ b/lib/ssllabs.js
@@ -277,7 +277,12 @@ module.exports.analyze = function (options, callback) {
 
 	options = _.defaults(options, defaults);
 
-	verifyOptions(options);
+	try {
+		verifyOptions(options);
+	} catch (e) {
+		callback(e, null);
+		return;
+	}
 
 	apiUrl = _.clone(api.endPoint);
 	apiUrl.pathname += "analyze";


### PR DESCRIPTION
I think it should catch the errors thrown while verifying options instead of let them block the process, so if the script is used inside other scripts it will fail without stopping global execution, for example if the host parameter is missing or some options where set incorrectly.

Also I think for callback-based (ie. asynchronous) code, if the first argument of the callback is err, like in this case it should always return errors instead of throwing them directly.

I found some ref about this patterns in [joyent guide](https://www.joyent.com/node-js/production/design/errors)